### PR TITLE
Extend globs in `opts.files`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 styleguide
+npm-debug.log

--- a/lib/rsg.js
+++ b/lib/rsg.js
@@ -9,6 +9,7 @@ var glob = require('glob')
 var mustache = require('mustache')
 var reactDocGen = require('react-docgen')
 var watchify = require('watchify')
+var globby = require('globby')
 
 /**
  * React Styleguide Generator
@@ -156,10 +157,16 @@ RSG.prototype.genReactPropDoc = function () {
 }
 
 RSG.prototype.copy = function (src, dest) {
+  function extractDirectoryPath(path) {
+    return path.substring(0, path.lastIndexOf("/"));
+  }
+
   return new Promise(function (resolve, reject) {
-    fs.copy(src, dest, function (err) {
-      if (err) { return reject(err) }
-      resolve()
+    fs.ensureDir(extractDirectoryPath(dest), function (err) {
+      fs.copy(src, dest, function (err) {
+        if (err) { return reject(err) }
+        resolve()
+      })
     })
   })
 }
@@ -175,17 +182,26 @@ RSG.prototype.copyOptsFiles = function () {
   var self = this;
   var copy = self.copy
   var output = self.opts.output
+  var imagesPattern = /\.jpe?g$|\.png$|\.svg$/;
 
-  var files = self.opts.files.filter(function (file) {
+  var matchingFiles = globby.sync(self.opts.files);
+  var files = matchingFiles.filter(function (file) {
     return fs.existsSync(file)
   })
+
+  function destination(file) {
+    var subDirs = ''
+    if (imagesPattern.test(file))
+      subDirs = 'images/'
+
+    return output + '/files/' + subDirs + path.basename(file)
+  }
 
   function copyFile(file, log) {
     if (log)
       self.log.info({ file: file }, 'file changed');
 
-    var dest = output + '/files/' + path.basename(file)
-    return copy(file, dest)
+    return copy(file, destination(file))
   }
 
   if (self.opts.watch) {
@@ -198,7 +214,8 @@ RSG.prototype.copyOptsFiles = function () {
 }
 
 RSG.prototype.extractFiles = function (ext) {
-  return this.opts.files
+  var matchingFiles = globby.sync(this.opts.files);
+  return matchingFiles
     .filter(function (file) { return path.extname(file) === ext })
     .map(function (file) {
 

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "css-modulesify": "^0.8.0",
     "fs-extra": "^0.20.1",
     "glob": "^5.0.10",
+    "globby": "^3.0.1",
     "minimist": "^1.1.1",
     "mustache": "^2.1.2",
     "object-assign": "^3.0.0",


### PR DESCRIPTION
Why:
- `opts.files` only accepts file paths
- for including an entire directory of files we should be able to define
  glob patterns that identifies it

This change addresses the need by:
- installing [globby](https://www.npmjs.com/package/globby) for extending
  `globs`
- extending `opts.files` with globby matching any possible `globs`
- adding an `/images` dir inside `/files` for any image file
