### PR TITLE
Add react-dom to window

### DIFF
--- a/lib/fixtures/index.html.mustache
+++ b/lib/fixtures/index.html.mustache
@@ -45,6 +45,7 @@
     <script src="src/react_{{reactVersion}}.js"></script>
     <script>
       window.React = require('react');
+      window.ReactDOM = require('react-dom');
     </script>
     <script src="src/contents.js"></script>
     <script src="src/app.js"></script>


### PR DESCRIPTION
Why:
- Since `react-dom` is excluded from the final bundle, the host has the requirement of exposing it in the `window`

This change addresses the need by:
- Assigning `react-dom` to `window`
